### PR TITLE
Feat/add rdl status auto reactivation

### DIFF
--- a/plugins/modules/rdl_server_status.ps1
+++ b/plugins/modules/rdl_server_status.ps1
@@ -8,12 +8,14 @@
 
 $spec = @{
     options             = @{
-        method       = @{ type = "str"; choices = "automatic", "manual"; default = "automatic" }
-        confirm_code = @{ type = "str" }
-        state        = @{ type = "str"; choices = "activated", "deactivated"; default = "activated" }
+        method              = @{ type = "str"; choices = "automatic", "manual"; default = "automatic" }
+        confirm_code        = @{ type = "str" }
+        reactivation_reason = @{ type = "str"; choices = "redeployment", "corrcupt_certificate", "compromised_private_key", "activation_key_expired", "server_upgrade" }
+        state               = @{ type = "str"; choices = "activated", "deactivated", "reactivated"; default = "activated" }
     }
     required_if         = @(
         , @("method", "manual", @("confirm_code"))
+        , @("state", "reactivated", @("reactivation_reason"))
     )
     supports_check_mode = $false
 }
@@ -23,15 +25,30 @@ $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 # Map variables
 $method = $module.Params.method
 $confirmCode = $module.Params.confirm_code
+$reactivationReason = $module.Params.reactivation_reason
 $state = $module.Params.state
 
 # ErrorAction
 $ErrorActionPreference = 'Stop'
 
 # Check confirm code
-if($confirmCode){
-    if($confirmCode -notmatch "^[a-zA-Z0-9]{35}$"){
+if ($confirmCode) {
+    if ($confirmCode -notmatch "^[a-zA-Z0-9]{35}$") {
         $module.FailJson("The confirm_code parameter must be a 35-character alphanumeric string that cannot include hyphens")
+    }
+}
+
+# Map reactivation reason
+if ($reactivationReason) {
+    switch ($reactivationReason) {
+        "redeployment" { $reactivationReasonID = 0 }
+        "corrcupt_certificate" { $reactivationReasonID = 1 }
+        "compromised_private_key" { $reactivationReasonID = 2 }
+        "activation_key_expired" { $reactivationReasonID = 3 }
+        "server_upgrade" { $reactivationReasonID = 4 }
+        Default {
+            $module.FailJson("The reactivation_reason value is not a valid option.")
+        }
     }
 }
 
@@ -111,24 +128,40 @@ if (($serverActivationStatus.ActivationStatus -eq 1) -and ($state -eq "activated
 }
 
 # Reactivate
-try {
-    $licenseID = $wmiClass.GetLicenseServerId()
-}
-catch {
-    $module.FailJson("Failed to retrieve license server id", $Error[0])
-}
+if ($state -eq "reactivated") {
+    if ($method -eq "manual") {
+        try {
+            $licenseID = $wmiClass.GetLicenseServerId()
+        }
+        catch {
+            $module.FailJson("Failed to retrieve license server id", $Error[0])
+        }
 
-if ($licenseID.sLicenseServerId -ne $confirmCode) {
-    try {
-        $result = $wmiClass.ReactivateServer()
-        if ($result.ActivationStatus -ne 0) {
-            $module.FailJson("Failed to reactivate the license server", $Error[0])
+        if ($licenseID.sLicenseServerId -ne $confirmCode) {
+            try {
+                $result = $wmiClass.ReactivateServer()
+                if ($result.ActivationStatus -ne 0) {
+                    $module.FailJson("Failed to reactivate the license server", $Error[0])
+                }
+            }
+            catch {
+                $module.FailJson("Failed to reactivate the license server", $Error[0])
+            }
+            $module.ExitJson()
         }
     }
-    catch {
-        $module.FailJson("Failed to reactivate the license server", $Error[0])
+    else {
+        try {
+            $result = $wmiClass.ReactivateServerAutomatic($reactivationReasonID)
+            if ($result.ActivationStatus -ne 0) {
+                $module.FailJson("Failed to reactivate the license server", $Error[0])
+            }
+        }
+        catch {
+            $module.FailJson("Failed to reactivate the license server", $Error[0])
+        }
+        $module.ExitJson()
     }
-    $module.ExitJson()
 }
 
 $module.ExitJson()

--- a/plugins/modules/rdl_server_status.py
+++ b/plugins/modules/rdl_server_status.py
@@ -23,6 +23,18 @@ options:
     - This parameter is required when the method is set to manual.
     type: str
     required: false
+  reactivation_reason:
+    description:
+    - Specify the reason for the reactivation of the license server.
+    - This parameter is required when method is set to C(automatic).
+    type: str
+    required: false
+    choices:
+    - redeployment
+    - corrcupt_certificate
+    - compromised_private_key
+    - activation_key_expired
+    - server_upgrade
   state:
     description:
     - Set to C(present) to ensure the exclusion range is present.


### PR DESCRIPTION
Added the ability to do a automatic reactivation to the rdl_server_status module.

This also fixes an issue where the module tries to reactivate the server status even if there is nothing to do.