### PR TITLE
Feat/add new module rdl server domain status

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Collection of windows ansible modules.
 | fsrm | fsrm_filegroup | Add or modify file groups |
 | fsrm | fsrm_setting | Modify general settings |
 | rdl | rdl_company_info | Add or remove the company info of the wmi object. |
+| rdl | rdl_server_domain_status | Add or remove the server to the Remote Desktop license server group in a given domain. |
 | rdl | rdl_server_status | Activate, deactivate or reactivate the remote desktop license server. |
 | wsus | wsus_computer_target_group | Add or remove a computer group. |
 | wsus | wsus_email_notification_setting | Modify email notification settings |

--- a/plugins/modules/rdl_server_domain_status.ps1
+++ b/plugins/modules/rdl_server_domain_status.ps1
@@ -1,0 +1,77 @@
+#!powershell
+
+# Copyright: (c) 2023, Dustin Strobel (@d-strobel), Yasmin Hinel (@yahikii)
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
+
+$spec = @{
+    options             = @{
+        domain = @{ type = "str"; required = $true }
+        state  = @{ type = "str"; choices = "absent", "present"; default = "present" }
+    }
+    supports_check_mode = $false
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+# Map variables
+$domain = $module.Params.domain
+$state = $module.Params.state
+
+# ErrorAction
+$ErrorActionPreference = 'Stop'
+
+# Get wmi class
+try {
+    $wmiClass = ([wmiclass]"\\localhost\root\cimv2:Win32_TSLicenseServer")
+}
+catch {
+    $module.FailJson("Failed to get wmi class 'Win32_TSLicenseServer'", $Error[0])
+}
+
+# Get server domain status
+try {
+    $serverDomainStatus = $wmiClass.IsLSinTSLSGroup($domain)
+}
+catch {
+    $module.FailJson("Failed to retrieve server domain status", $Error[0])
+}
+
+# Early exit
+if ((-not $serverDomainStatus.IsMember) -and ($state -eq "absent")) {
+    $module.ExitJson()
+}
+
+# Absent
+if (($serverDomainStatus.IsMember) -and ($state -eq "absent")) {
+    try {
+        $result = $wmiClass.RemoveLSfromTSLSGroup()
+        if ($result.ReturnValue -ne 0) {
+            $module.FailJson("Failed to remove the license server from the domain")
+        }
+    }
+    catch {
+        $module.FailJson("Failed to remove the license server from the domain", $Error[0])
+    }
+
+    $module.ExitJson()
+}
+
+# Present
+if ((-not $serverDomainStatus.IsMember) -and ($state -eq "present")) {
+    try {
+        $result = $wmiClass.AddLStoTSLSGroup()
+        if ($result.ReturnValue -ne 0) {
+            $module.FailJson("Failed to add the license server to the domain")
+        }
+    }
+    catch {
+        $module.FailJson("Failed to add the license server to the domain", $Error[0])
+    }
+
+    $module.ExitJson()
+}
+
+$module.ExitJson()

--- a/plugins/modules/rdl_server_domain_status.py
+++ b/plugins/modules/rdl_server_domain_status.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Dustin Strobel (@d-strobel),
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: rdl_server_domain_status
+short_description: Add or remove the server to the Remote Desktop license server group in a given domain.
+description:
+- Add or remove the server to the Remote Desktop license server group in a given domain.
+options:
+  domain:
+    description:
+    - Define the domain name.
+    type: str
+    required: true
+  state:
+    description:
+    - Set to C(present) to ensure the server is present in the Remote Desktop license server group.
+    - Set to C(absent) to ensure the server is removed from the Remote Desktop license server group.
+    type: str
+    default: present
+    choices: [ present, absent ]
+
+author:
+- Dustin Strobel (@d-strobel)
+'''


### PR DESCRIPTION
Added the module rdl_server_domain_status. This is used to add or remove the server to the Remote Desktop license server group in a given domain.