### PR TITLE
fix: wrong parameter type

### DIFF
--- a/plugins/modules/win_scheduled_task.ps1
+++ b/plugins/modules/win_scheduled_task.ps1
@@ -12,7 +12,7 @@ $spec = @{
     options             = @{
         name   = @{ type = "str"; required = $true }
         description = @{ type = "str" }
-        actions     = @{ type = "dict"; options = @{
+        actions     = @{ type = "list"; options = @{
                 arguments = @{ type = "str" }
                 execute   = @{ type = "str" }
             }
@@ -20,7 +20,7 @@ $spec = @{
                 , @("actions", $true, @("arguments", "execute"))
             )
         }
-        triggers    = @{ type = "dict"; options = @{
+        triggers    = @{ type = "list"; options = @{
                 start_time  = @{ type = "str" }
                 day_of_week = @{ type = "str"; choices = "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" }
                 frequency   = @{ type = "str"; choices = "once", "daily", "weekly"; default = "once" }


### PR DESCRIPTION
Closes #10 
Changed the type of the parameter actions and triggers from dictionary to list